### PR TITLE
Remove hobbies page and redesign about section

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,7 +14,6 @@ import { DarkModeToggle } from './components/toggledarkmode';
 import Home from './pages/Home';
 import Resume from './pages/Resume';
 import Projects from './pages/Projects';
-import Hobbies from './pages/Hobbies';
 import Contact from './pages/Contact';
 import About from './pages/About';
 import NotFound from './pages/NotFound';
@@ -41,9 +40,8 @@ function App() {
             <Route path="/" element={<Home />} />
             <Route path="/Resume" element={<Resume />} />
             <Route path="/Projects" element={<Projects />} />
-            <Route path="/Hobbies" element={<Hobbies />} />
             <Route path="/Contact" element={<Contact />} />
-            <Route path="/about" element={<About />} />
+            <Route path="/About" element={<About />} />
             <Route path="*" element={<NotFound />} />
           </Routes>
         </Container>

--- a/src/Assets/about.ts
+++ b/src/Assets/about.ts
@@ -1,0 +1,12 @@
+// Assets/about.ts
+
+export const aboutContent = {
+  title: 'About Me',
+  paragraphs: [
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus. Suspendisse lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed, dolor.',
+    'Cras elementum ultrices diam. Maecenas ligula massa, varius a, semper congue, euismod non, mi.',
+    'Proin porttitor, orci nec nonummy molestie, enim est eleifend mi, non fermentum diam nisl sit amet erat.',
+  ],
+};
+
+export default aboutContent;

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -16,7 +16,6 @@ const pages = [
   { label: 'Home', to: '/' },
   { label: 'Resume', to: '/Resume' },
   { label: 'Projects', to: '/Projects' },
-  { label: 'Hobbies', to: '/Hobbies' },
   { label: 'About', to: '/About' },
 ];
 

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,7 +1,24 @@
 import React from 'react';
+import { Container, Card, CardContent, Typography } from '@mui/material';
+import { aboutContent } from '../Assets/about';
 
 const About: React.FC = () => {
-  return <div>This is the About page</div>;
+  return (
+    <Container maxWidth="md" className="py-6">
+      <Card className="shadow">
+        <CardContent>
+          <Typography variant="h4" gutterBottom>
+            {aboutContent.title}
+          </Typography>
+          {aboutContent.paragraphs.map((text, idx) => (
+            <Typography key={idx} paragraph>
+              {text}
+            </Typography>
+          ))}
+        </CardContent>
+      </Card>
+    </Container>
+  );
 };
 
 export default About;

--- a/src/pages/Hobbies.tsx
+++ b/src/pages/Hobbies.tsx
@@ -1,8 +1,0 @@
-// pages/Hobbies.tsx
-import React from 'react';
-
-const Hobbies: React.FC = () => {
-  return <div>This is the Hobbies page</div>;
-};
-
-export default Hobbies;


### PR DESCRIPTION
## Summary
- remove obsolete Hobbies page and navigation entry
- revamp About page with professional layout and placeholder content

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b850db41b8832eb91cc832a041364c